### PR TITLE
fix line 61 to properly print eml format

### DIFF
--- a/scripts/tnp3xxx.py
+++ b/scripts/tnp3xxx.py
@@ -58,6 +58,6 @@ if __name__ == '__main__':
         for sector in range(0, 16):
             keysa.append(calc_keya(sys.argv[1], sector).upper())
         if len(sys.argv) > 2 and sys.argv[2] == '-eml':
-            print('0'*20+'\n'+('0'*32+'\n')*3).join(keysa).join([(sys.argv[1]+'0'*24+'\n')+(('0'*32+'\n')*2), '0'*20])
+            print(('0'*20+'\n'+('0'*32+'\n')*3).join(keysa).join([(sys.argv[1]+'0'*24+'\n')+(('0'*32+'\n')*2), '0'*20]))
         else:
             print('\n'.join(keysa))


### PR DESCRIPTION
when converting the script to python3, someone forgot to enclose line 61 in parenthesis, effectively closing the print statement early and causing the error below:

```bash
    print('0'*20+'\n'+('0'*32+'\n')*3).join(keysa).join([(sys.argv[1]+'0'*24+'\n')+(('0'*32+'\n')*2), '0'*20])
AttributeError: 'NoneType' object has no attribute 'join'
```